### PR TITLE
Agregar redes y lista de vídeos de YT a README

### DIFF
--- a/.github/workflows/youtube-workflow.yml
+++ b/.github/workflows/youtube-workflow.yml
@@ -14,4 +14,5 @@ jobs:
       - name: Pull in dev.to posts
         uses: gautamkrishnar/blog-post-workflow@master
         with:
+          comment_tag_name: "YOUTUBE"
           feed_list: "https://www.youtube.com/channel/UC_O43Juzt06b9kgP0d-QgSQ/videos"

--- a/.github/workflows/youtube-workflow.yml
+++ b/.github/workflows/youtube-workflow.yml
@@ -15,4 +15,4 @@ jobs:
         uses: gautamkrishnar/blog-post-workflow@master
         with:
           comment_tag_name: "YOUTUBE"
-          feed_list: "https://www.youtube.com/channel/UC_O43Juzt06b9kgP0d-QgSQ/videos"
+          feed_list: "https://www.youtube.com/feeds/videos.xml?channel_id=UC_O43Juzt06b9kgP0d-QgSQ"

--- a/.github/workflows/youtube-workflow.yml
+++ b/.github/workflows/youtube-workflow.yml
@@ -1,0 +1,17 @@
+name: Latest youtube videos workflow
+on:
+  schedule: # Run workflow automatically
+    - cron: '0 * * * *' # Runs every hour, on the hour
+  workflow_dispatch: # Run workflow manually (without waiting for the cron to be called), through the Github Actions Workflow page directly
+
+jobs:
+  update-readme-with-blog:
+    name: Update this repo's README with latest youtube videos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Pull in dev.to posts
+        uses: gautamkrishnar/blog-post-workflow@master
+        with:
+          feed_list: "https://www.youtube.com/channel/UC_O43Juzt06b9kgP0d-QgSQ/videos"

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
  Se subirán códigos y presentaciones que se hagan.
  
  ## Nuestras redes 
- [![][badge-meetup]][url-meetup] [![][badge-linkedin]][url-linkedin] [![][badge-youtube]][url-youtube] [![][badge-twitter]][url-twitter] [![][badge-telegram]][url-telegram] [![][badge-slack]][url-slack] [![][badge-discord]][url-discord]
+ [![][badge-meetup]][url-meetup] [![][badge-linkedin]][url-linkedin] [![][badge-youtube]][url-youtube] [![][badge-twitter]][url-twitter] [![][badge-slack]][url-slack] [![][badge-discord]][url-discord] [![][badge-telegram]][url-telegram]
  
  ## Nuestras redes 
- [![][badge-meetup-full]][url-meetup] [![][badge-linkedin-full]][url-linkedin] [![][badge-youtube-full]][url-youtube] [![][badge-twitter-full]][url-twitter] [![][badge-telegram-full]][url-telegram] [![][badge-slack]][url-slack] [![][badge-discord-full]][url-discord]
+ [![][badge-meetup-full]][url-meetup] [![][badge-linkedin-full]][url-linkedin] [![][badge-youtube-full]][url-youtube] [![][badge-twitter-full]][url-twitter] [![][badge-slack]][url-slack] [![][badge-discord-full]][url-discord] [![][badge-telegram-full]][url-telegram]
 
 ## Nuestras últimas charlas 
 <!-- YOUTUBE:START -->

--- a/README.md
+++ b/README.md
@@ -1,9 +1,34 @@
-# TFUG Santiago
- 
+# TFUG Santiago 
  Repositorio oficial del grupo [TFUG Santiago](https://www.meetup.com/es/TensorFlow-Santiago/), el cual es parte de los grupos oficiales de [Google](https://www.tensorflow.org/community/groups?authuser=1).
  
  Se subirán códigos y presentaciones que se hagan.
  
+ ## Nuestras redes 
+ [![][badge-linkedin]][url-linkedin] [![][badge-twitter]][url-twitter] [![][badge-meetup]][url-meetup] [![][badge-youtube]][url-youtube] [![][badge-telegram]][url-telegram] [![][badge-slack]][url-slack] [![][badge-discord]][url-discord]
+
+ 
  # Tabla de contenidos:
  
  - [30 Days of ML](https://github.com/danpereda/TFUG_Santiago/tree/main/30%20Days%20of%20ML): Notebooks sobre técnicas y temas importantes para sacar la máxima performance de un modelo.
+
+<!-- Badges and links -->
+[badge-linkedin]: https://img.shields.io/static/v1?label=TensorFlow%20and%20ML%20User%20Group%20Santiago&message=LinkedIn&style=for-the-badge&logo=linkedin&color=0A66C2 
+[url-linkedin]: https://www.linkedin.com/company/tensorflow-user-group-santiago
+
+[badge-slack]: https://img.shields.io/static/v1?label=%20&message=Slack&style=for-the-badge&logo=slack&color=4A154B 
+[url-slack]: https://join.slack.com/t/tensorflow-chile/shared_invite/zt-wphk5zhv-A5YRRu3esCUHKRKC4rtTJg 
+
+[badge-twitter]: https://img.shields.io/static/v1?label=@UserSantiago&message=Twitter&style=for-the-badge&logo=twitter&color=1DA1F2
+[url-twitter]: https://twitter.com/UserSantiago 
+
+[badge-telegram]: https://img.shields.io/static/v1?label=TensorFlow-Chile&message=Telegram&style=for-the-badge&logo=telegram&color=26A5E4 
+[url-telegram]: https://t.me/joinchat/3XBhc9ORx_4xYjc5
+
+[badge-meetup]: https://img.shields.io/static/v1?label=TensorFlow%20Santiago&message=MeetUp&style=for-the-badge&logo=meetup&color=ED1C40 
+[url-meetup]: https://www.meetup.com/TensorFlow-Santiago/
+
+[badge-youtube]: https://img.shields.io/static/v1?label=TFUG%20Santiago%20Chile&message=YouTube&style=for-the-badge&logo=youtube&color=FF0000
+[url-youtube]: https://www.youtube.com/channel/UC_O43Juzt06b9kgP0d-QgSQ 
+
+[badge-discord]: https://img.shields.io/static/v1?label=TFUG%20Chile&message=Discord&style=for-the-badge&logo=discord&color=5865F2
+[url-discord]: https://discord.gg/dcVsdjPT

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
  ## Nuestras redes 
  [![][badge-linkedin]][url-linkedin] [![][badge-twitter]][url-twitter] [![][badge-meetup]][url-meetup] [![][badge-youtube]][url-youtube] [![][badge-telegram]][url-telegram] [![][badge-slack]][url-slack] [![][badge-discord]][url-discord]
 
+## Nuestras últimas charlas 
+<!-- YOUTUBE:START -->
+<!-- YOUTUBE:END -->
  
  # Tabla de contenidos:
  

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@
  Se subirán códigos y presentaciones que se hagan.
  
  ## Nuestras redes 
- [![][badge-linkedin]][url-linkedin] [![][badge-twitter]][url-twitter] [![][badge-meetup]][url-meetup] [![][badge-youtube]][url-youtube] [![][badge-telegram]][url-telegram] [![][badge-slack]][url-slack] [![][badge-discord]][url-discord]
+ [![][badge-meetup]][url-meetup] [![][badge-linkedin]][url-linkedin] [![][badge-youtube]][url-youtube] [![][badge-twitter]][url-twitter] [![][badge-telegram]][url-telegram] [![][badge-slack]][url-slack] [![][badge-discord]][url-discord]
+ 
+ ## Nuestras redes 
+ [![][badge-meetup-full]][url-meetup] [![][badge-linkedin-full]][url-linkedin] [![][badge-youtube-full]][url-youtube] [![][badge-twitter-full]][url-twitter] [![][badge-telegram-full]][url-telegram] [![][badge-slack]][url-slack] [![][badge-discord-full]][url-discord]
 
 ## Nuestras últimas charlas 
 <!-- YOUTUBE:START -->
@@ -15,23 +18,29 @@
  - [30 Days of ML](https://github.com/danpereda/TFUG_Santiago/tree/main/30%20Days%20of%20ML): Notebooks sobre técnicas y temas importantes para sacar la máxima performance de un modelo.
 
 <!-- Badges and links -->
-[badge-linkedin]: https://img.shields.io/static/v1?label=TensorFlow%20and%20ML%20User%20Group%20Santiago&message=LinkedIn&style=for-the-badge&logo=linkedin&color=0A66C2 
+[badge-linkedin-full]: https://img.shields.io/static/v1?label=TensorFlow%20and%20ML%20User%20Group%20Santiago&message=LinkedIn&style=for-the-badge&logo=linkedin&color=0A66C2 
+[badge-linkedin]: https://img.shields.io/static/v1?label=&message=LinkedIn&style=for-the-badge&logo=linkedin&color=0A66C2
 [url-linkedin]: https://www.linkedin.com/company/tensorflow-user-group-santiago
 
 [badge-slack]: https://img.shields.io/static/v1?label=%20&message=Slack&style=for-the-badge&logo=slack&color=4A154B 
 [url-slack]: https://join.slack.com/t/tensorflow-chile/shared_invite/zt-wphk5zhv-A5YRRu3esCUHKRKC4rtTJg 
 
-[badge-twitter]: https://img.shields.io/static/v1?label=@UserSantiago&message=Twitter&style=for-the-badge&logo=twitter&color=1DA1F2
+[badge-twitter-full]: https://img.shields.io/static/v1?label=@UserSantiago&message=Twitter&style=for-the-badge&logo=twitter&color=1DA1F2
+[badge-twitter]: https://img.shields.io/static/v1?label&message=Twitter&style=for-the-badge&logo=twitter&color=1DA1F2&logoColor=white
 [url-twitter]: https://twitter.com/UserSantiago 
 
-[badge-telegram]: https://img.shields.io/static/v1?label=TensorFlow-Chile&message=Telegram&style=for-the-badge&logo=telegram&color=26A5E4 
+[badge-telegram-full]: https://img.shields.io/static/v1?label=TensorFlow-Chile&message=Telegram&style=for-the-badge&logo=telegram&color=26A5E4 
+[badge-telegram]: https://img.shields.io/static/v1?label=&message=Telegram&style=for-the-badge&logo=telegram&color=26A5E4
 [url-telegram]: https://t.me/joinchat/3XBhc9ORx_4xYjc5
 
-[badge-meetup]: https://img.shields.io/static/v1?label=TensorFlow%20Santiago&message=MeetUp&style=for-the-badge&logo=meetup&color=ED1C40 
+[badge-meetup-full]: https://img.shields.io/static/v1?label=TensorFlow%20Santiago&message=MeetUp&style=for-the-badge&logo=meetup&color=ED1C40 
+[badge-meetup]: https://img.shields.io/static/v1?label=&message=MeetUp&style=for-the-badge&logo=meetup&color=ED1C40
 [url-meetup]: https://www.meetup.com/TensorFlow-Santiago/
 
-[badge-youtube]: https://img.shields.io/static/v1?label=TFUG%20Santiago%20Chile&message=YouTube&style=for-the-badge&logo=youtube&color=FF0000
+[badge-youtube-full]: https://img.shields.io/static/v1?label=TFUG%20Santiago%20Chile&message=YouTube&style=for-the-badge&logo=youtube&color=FF0000
+[badge-youtube]: https://img.shields.io/static/v1?label=&message=YouTube&style=for-the-badge&logo=youtube&color=FF0000
 [url-youtube]: https://www.youtube.com/channel/UC_O43Juzt06b9kgP0d-QgSQ 
 
-[badge-discord]: https://img.shields.io/static/v1?label=TFUG%20Chile&message=Discord&style=for-the-badge&logo=discord&color=5865F2
+[badge-discord-full]: https://img.shields.io/static/v1?label=TFUG%20Chile&message=Discord&style=for-the-badge&logo=discord&color=5865F2
+[badge-discord]: https://img.shields.io/static/v1?label=&message=Discord&style=for-the-badge&logo=discord&color=5865F2&logoColor=white
 [url-discord]: https://discord.gg/dcVsdjPT


### PR DESCRIPTION
Implementé un par de cambios para mejorar un poco el README.

# Badges de nuestras redes 
Agregué badges con links dirigiendo a linkedin, youtube, slack, etc. Hice dos versiones pero me gusta más la primera. Lo dejo a tu gusto @danpereda.

# Workflow para los vídeos de YouTube 

Agregué una *github action* basada en [blog-post-workflow](https://github.com/gautamkrishnar/blog-post-workflow) que actualiza automáticamente el README del proyecto con links a los últimos 5 videos del canal. La *action* busca las líneas 
```
<!-- YOUTUBE:START -->
<!-- YOUTUBE:END -->
```
(que están bajo la subsección **Nuestras últimas charlas**) e inserta los links dentro. Está configurada para correr automáticamente una vez cada hora. También es posible correrla manualmente, que es lo que recomiendo la primera vez para verificar que esté funcionando. 


*PD: Al principio hice los cambios en mi main branch, y ahí la action funcionó bien. Pero tengo entendido que es más complicado hacer merge si los cambios están en el main (??), así que los moví a una branch `update-readme`. Y ahora, a pesar de que el workflow existe, no puedo correrlo (me sale que la action no existe). Imagino que puede ser por no estar en la main branch (vi [esta discusión vieja](https://github.community/t/workflow-files-only-picked-up-from-master/16129)) pero no estoy segura. De todas formas, imagino que se podrá correr una vez que se haga merge con la main branch.*
